### PR TITLE
Fix vehicle data API route export

### DIFF
--- a/app/api/vehicle-data/route.ts
+++ b/app/api/vehicle-data/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { VehicleData } from '@/types/carbon';
 
 // Mock vehicle data for development - replace with Google Sheets integration
-export function getMockVehicleData(): VehicleData[] {
+function getMockVehicleData(): VehicleData[] {
   return [
     // Example vehicle data - replace with your actual data
     { schoolName: "Hollingwood Primary School", vehicleType: "Car", fuelType: "Petrol", mileage: 1200, year: 2025, month: "October" },

--- a/components/CarbonReportingDashboard.tsx
+++ b/components/CarbonReportingDashboard.tsx
@@ -42,7 +42,7 @@ export default function CarbonReportingDashboard() {
   };
 
   const secrReport = generateSECRReport(energyData, vehicleData, selectedYear, pupilCount);
-  const availableYears = [...new Set(energyData.map(d => d.year))].sort();
+  const availableYears = Array.from(new Set(energyData.map((d) => d.year))).sort((a, b) => a - b);
 
   const exportSECRReport = () => {
     const reportData = {

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -117,14 +117,14 @@ export default function Dashboard() {
 
   const getAvailableMeters = () => {
     const schoolData = filters.school === 'All Schools' ? data : data.filter(d => d.schoolName === filters.school);
-    return [...new Set(schoolData.map(d => d.meterNumber))].sort();
+    return Array.from(new Set(schoolData.map(d => d.meterNumber))).sort();
   };
 
   const getDateRangeDisplay = () => {
     if (filteredData.length === 0) return 'No data in selected range';
-    
+
     if (filters.compareMonth !== 'All') {
-      const years = [...new Set(filteredData.map(d => d.year))].sort();
+      const years = Array.from(new Set(filteredData.map(d => d.year))).sort((a, b) => a - b);
       return `Comparing ${filters.compareMonth} for years: ${years.join(', ')}`;
     } else {
       const dates = filteredData.map(d => new Date(d.year, allMonths.indexOf(d.month)));

--- a/components/FilterPanel.tsx
+++ b/components/FilterPanel.tsx
@@ -19,9 +19,9 @@ export function FilterPanel({
   availableMeters, 
   allMonths 
 }: FilterPanelProps) {
-  const schools = [...new Set(data.map(d => d.schoolName))].sort();
-  const energyTypes = [...new Set(data.map(d => d.energyType))].sort();
-  const years = [...new Set(data.map(d => d.year))].sort();
+  const schools = Array.from(new Set(data.map(d => d.schoolName))).sort();
+  const energyTypes = Array.from(new Set(data.map(d => d.energyType))).sort();
+  const years = Array.from(new Set(data.map(d => d.year))).sort((a, b) => a - b);
 
   const handleFilterChange = (key: keyof FilterState, value: string | number) => {
     const newFilters = { ...filters, [key]: value };


### PR DESCRIPTION
## Summary
- prevent the mock data helper in the vehicle data API route from being exported so the module only exposes the GET handler

## Testing
- npm run build *(fails: fetches Google Fonts and the container has no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d25a5e3550832fa2452bba357382d2